### PR TITLE
Removed version attribute from meta/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,4 +14,4 @@ galaxy_info:
     - system
     - application
 dependencies: []
-version: 2.0.0
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Update apt
   apt: update_cache=yes
-  sudo: yes
+  become: yes
 
 - name: Install Imagemagick
   action: apt pkg={{ item }} state=latest
-  sudo: yes
+  become: yes
   with_items:
     - imagemagick
     - libmagickcore-dev


### PR DESCRIPTION
Unsupported attributes in the meta/main.yml file cause an error in Ansible 2.0
